### PR TITLE
Add debugging flags to make NSight work automatically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,9 +32,7 @@ if(CUDA_FOUND)
     endif (UNIX)
 
     # add debugging to CUDA NVCC flags.  For NVidia's NSight tools.
-    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-	set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} "-G")
-    endif (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(CUDA_NVCC_FLAGS_DEBUG ${CUDA_NVCC_FLAGS_DEBUG} "-G")
 
     add_subdirectory (HW1)
     add_subdirectory (HW2)


### PR DESCRIPTION
This lets students set breakpoints and use the fancy debugging tools in NSight.  Without this modification, the debugging information was not being generated, and no debugging features were available.
