### PR TITLE
Fixed stack overflow error (Lesson 2, atomics)

### DIFF
--- a/Lesson Code Snippets/Lesson 2 Code Snippets/atomics.cu
+++ b/Lesson Code Snippets/Lesson 2 Code Snippets/atomics.cu
@@ -40,7 +40,7 @@ int main(int argc,char **argv)
            NUM_THREADS, NUM_THREADS / BLOCK_WIDTH, ARRAY_SIZE);
 
     // declare and allocate host memory
-    int h_array[ARRAY_SIZE];
+    int *h_array = new int[ARRAY_SIZE];
     const int ARRAY_BYTES = ARRAY_SIZE * sizeof(int);
  
     // declare, allocate, and zero out GPU memory


### PR DESCRIPTION
int h_array[ARRAY_SIZE] caused the stack overflow for a huge ARRAY_SIZE value (this issue was reported on forums). Using a pointer solved this problem.